### PR TITLE
add click functionality to district cards in ComparisonContainer

### DIFF
--- a/src/CardContainer.js
+++ b/src/CardContainer.js
@@ -20,8 +20,10 @@ const CardContainer = (props) => {
     <div>
       { props.clickedCards.length > 0 &&
         <ComparisonContainer
+          handleClicked={props.handleClicked}
           comparisonData={props.comparisonData}
-          clickedCards={props.clickedCards.reduce((acc, card) => {
+          clickedCards={props.clickedCards}
+          clickedCardData={props.clickedCards.reduce((acc, card) => {
             acc[card.location] = card;
             return acc;
           }, {})}/>

--- a/src/ComparisonContainer.js
+++ b/src/ComparisonContainer.js
@@ -4,14 +4,16 @@ import Card from './Card';
 // import './ComparisonContainer.css';
 
 const ComparisonContainer = (props) => {
-  const keys = Object.keys(props.clickedCards);
+  const keys = Object.keys(props.clickedCardData);
 
   const mapped = keys.map( (key, index) => {
     return <Card
       cardType='districtCard'
-      location={props.clickedCards[key].location}
-      yearData={props.clickedCards[key].yearData}
+      isClicked={(props.clickedCards.find(cc => cc.location === props.clickedCardData[key].location) !== undefined)}
+      location={props.clickedCardData[key].location}
+      yearData={props.clickedCardData[key].yearData}
       key={index+1 + Date.now()}
+      handleClicked={props.handleClicked}
            />
   })
     const comparison = <Card


### PR DESCRIPTION
add the ability to click on the district cards in ComparisonContainer to remove them from the comparison. you can now click on the card in the big list to remove it or click it in the comparison to remove it. 